### PR TITLE
Fix vendor/composer/installed.json format changed

### DIFF
--- a/src/ManifestManager.php
+++ b/src/ManifestManager.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace EasyWeChatComposer;
 
+use Composer\Plugin\PluginInterface;
+
 class ManifestManager
 {
     const PACKAGE_TYPE = 'easywechat-extension';
@@ -66,6 +68,9 @@ class ManifestManager
 
         if (file_exists($installed = $this->vendorPath.'/composer/installed.json')) {
             $packages = json_decode(file_get_contents($installed), true);
+            if (version_compare(PluginInterface::PLUGIN_API_VERSION, '2.0.0', 'ge')) {
+                $packages = $packages['packages'];
+            }
         }
 
         $this->write($this->map($packages));


### PR DESCRIPTION
[Upgrade guides for Composer 1.x to 2.0 - For integrators and plugin authors](https://github.com/composer/composer/blob/2.0.0-alpha2/UPGRADE-2.0.md#for-integrators-and-plugin-authors)

- `vendor/composer/installed.json` format changed:
  - packages are now wrapped into a `"packages"` top level key instead of the whole file being the package array
  - packages now contain an `"installed-path"` key which lists where they were installed
  - there is a top level `"dev"` key which stores whether dev requirements were installed or not